### PR TITLE
Fix tags column name length. Set non-nullable user selection for post

### DIFF
--- a/database/migrations/create_blog_tables.php.stub
+++ b/database/migrations/create_blog_tables.php.stub
@@ -73,7 +73,7 @@ return new class () extends Migration {
 
         Schema::create('tags', function (Blueprint $table) {
             $table->id();
-            $table->string('name', 50)->unique();
+            $table->string('name', 155)->unique();
             $table->string('slug', 155)->unique();
             $table->timestamps();
         });

--- a/database/migrations/create_blog_tables.php.stub
+++ b/database/migrations/create_blog_tables.php.stub
@@ -73,7 +73,7 @@ return new class () extends Migration {
 
         Schema::create('tags', function (Blueprint $table) {
             $table->id();
-            $table->string('name', 155)->unique();
+            $table->string('name', 50)->unique();
             $table->string('slug', 155)->unique();
             $table->timestamps();
         });

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -216,6 +216,7 @@ class Post extends Model
                         ]),
                     Select::make(config('filamentblog.user.foreign_key'))
                         ->relationship('user', 'name')
+                        ->nullable(false)
                         ->default(auth()->id()),
 
                 ]),

--- a/src/Models/Tag.php
+++ b/src/Models/Tag.php
@@ -38,12 +38,12 @@ class Tag extends Model
                 ))
                 ->unique('tags', 'name', null, 'id')
                 ->required()
-                ->maxLength(155),
+                ->maxLength(50),
 
             TextInput::make('slug')
                 ->unique('tags', 'slug', null, 'id')
                 ->readOnly()
-                ->maxLength(255),
+                ->maxLength(155),
         ];
     }
 


### PR DESCRIPTION
1. Tag name validation requires length to be less than 155, but the column length is 50.
2. It's allowed select empty user while creating post, which violates not null exception.