### PR TITLE
PostResource > getNavigationBadge(): Return type fixes

### DIFF
--- a/src/Resources/PostResource.php
+++ b/src/Resources/PostResource.php
@@ -36,9 +36,9 @@ class PostResource extends Resource
 
     protected static SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
-    public static function getNavigationBadge(): ?int
+    public static function getNavigationBadge(): ?string
     {
-        return Post::count();
+        return strval(Post::count());
     }
 
     public static function form(Form $form): Form

--- a/src/Resources/PostResource.php
+++ b/src/Resources/PostResource.php
@@ -36,7 +36,7 @@ class PostResource extends Resource
 
     protected static SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
-    public static function getNavigationBadge(): ?string
+    public static function getNavigationBadge(): ?int
     {
         return Post::count();
     }


### PR DESCRIPTION
Error:

> Firefly\FilamentBlog\Resources\PostResource::getNavigationBadge(): Return value must be of type ?string, int returned

Filament V3
Laravel 11

fixed by use strval function in return