### PR TITLE
Fixed relations with custom user name property

### DIFF
--- a/src/Models/Comment.php
+++ b/src/Models/Comment.php
@@ -65,7 +65,7 @@ class Comment extends Model
     {
         return [
             Select::make('user_id')
-                ->relationship('user', 'name')
+                ->relationship('user', config('filamentblog.user.columns.name'))
                 ->required(),
             Select::make('post_id')
                 ->relationship('post', 'title')

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -216,7 +216,7 @@ class Post extends Model
                                 ->native(false),
                         ]),
                     Select::make(config('filamentblog.user.foreign_key'))
-                        ->relationship('user', 'name')
+                        ->relationship('user', config('filamentblog.user.columns.name'))
                         ->nullable(false)
                         ->default(auth()->id()),
 

--- a/src/Resources/PostResource/Pages/ManagePostComments.php
+++ b/src/Resources/PostResource/Pages/ManagePostComments.php
@@ -48,7 +48,7 @@ class ManagePostComments extends ManageRelatedRecords
         return $form
             ->schema([
                 Select::make('user_id')
-                    ->relationship('user', 'name')
+                    ->relationship('user', config('filamentblog.user.columns.name'))
                     ->required(),
                 Textarea::make('comment')
                     ->required()


### PR DESCRIPTION
There were three places which used static user "name" property, which caused errors:

`Column not found: 1054 Unknown column 'users.name' in 'field list'`

 This pull request fixes them.