### PR TITLE
fix(footer): use dynamic current year instead of hardcoded 2024

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -242,7 +242,7 @@
                 </div>
                 <div class="mt-7 flex flex-wrap items-start justify-center gap-10 border-t border-slate-200 pt-5">
                     <div class="text-hurricane/50 text-sm font-medium">
-                        © 2024 {{ $setting->organization_name ?? 'Firefly Blog' }}. All rights reserved.
+                        © {{ now()->year }} {{ $setting->organization_name ?? 'Firefly Blog' }}. All rights reserved.
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This change replaces the hard-coded year 2024 in the site footer with a dynamic value so the footer always shows the current year.