### PR TITLE
[FIX]: fixed content overflow issue in post form

### DIFF
--- a/src/Resources/Posts/Schemas/PostForm.php
+++ b/src/Resources/Posts/Schemas/PostForm.php
@@ -70,7 +70,7 @@ class PostForm
                         ]),
 
                     RichEditor::make('body')
-                        ->extraInputAttributes(['style' => 'max-height: 30rem; min-height: 24rem'])
+                        ->extraInputAttributes(['style' => 'min-height: 24rem'])
                         ->required()
                         ->columnSpanFull(),
 


### PR DESCRIPTION
This pull request makes a small adjustment to the styling of the `RichEditor` component in the post form schema. The change removes the maximum height restriction, allowing the editor to expand beyond 30rem if needed.