### PR TITLE
Enhance: Improve post body rendering – headings, blockquotes, code, lists & preserve empty spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The Filament Blog Plugin is a feature-rich plugin designed to enhance your blogg
 - **Newsletter Subscription:** Integrate newsletter subscription forms to grow your email list.
 - **New Post Published Notification:** Notify subscribers when a new blog post is published.
 - **Category Search:** Categorize your blog posts for easy navigation and search.
+- **Preserve Empty Paragraphs:** Keep user‑added blank lines in the post content (configurable).
 - **Support**: [Laravel 11](https://laravel.com) and [Filament 3.x](https://filamentphp.com)
 
 - **Table of Contents (TOC)**: Automatically generate a table of contents from headings inside a post body. This is configurable via the package config (see below).
@@ -168,6 +169,7 @@ return [
             'title' => true, // Whether to include the manual post title as first TOC entry
 
         ],
+        'preserve_space_in_content' => false, // Replace empty <p> tags with &nbsp; to keep blank lines
     ],
 ];
 ````

--- a/config/filamentblog.php
+++ b/config/filamentblog.php
@@ -93,6 +93,7 @@ return [
             'title' => false, // Whether to include the manual post title as first TOC entry
 
         ],
+        'preserve_space_in_content' => false, // This feature will preserve the space in the content by replacing empty paragraphs with non-breaking spaces.
     ],
 
     /**

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -84,6 +84,7 @@
         article h1 {
             line-height: 1.2;
             font-size: 2rem;
+            margin-top: 1.5em;
             color: #424242;
             font-weight: 900;
             padding-bottom: 20px;
@@ -92,6 +93,7 @@
         article h2 {
             line-height: 1.2;
             font-size: 1.5rem;
+            margin-top: 1.25em;
             color: #424242;
             font-weight: 800;
             padding-bottom: 10px;
@@ -100,6 +102,7 @@
         article h3 {
             line-height: 1.2;
             font-size: 1.25rem;
+            margin-top: 1em;
             color: #424242;
             font-weight: 700;
             padding-bottom: 10px;
@@ -108,11 +111,46 @@
         article h4 {
             line-height: 1.2;
             font-size: 1.2rem;
+            margin-top: 1em;
             color: #424242;
             font-weight: 600;
             padding-bottom: 10px;
         }
+        article h5 {
+            margin-top: 0.75em;
+            margin-bottom: 0.5em;
+            font-size: 0.9rem;
+            font-weight: 600;
+        }
+        article h6 {
+            margin-top: 0.5em;
+            margin-bottom: 0.25em;
+            font-size: 0.8rem;
+            font-weight: 600;
+            color: #555;
+        }
 
+        article blockquote {
+            margin: 1.5em 0;
+            padding-left: 1em;
+            border-left: 4px solid #ccc;
+            font-style: italic;
+            color: #555;
+        }
+
+        article pre {
+            background: #f4f4f4;
+            padding: 1em;
+            border-radius: 5px;
+            overflow-x: auto;
+            margin: 1em 0;
+        }
+        article code {
+            background: #f4f4f4;
+            padding: 0.2em 0.4em;
+            border-radius: 3px;
+            font-family: monospace;
+        }
         article p {
             line-height: 1.75;
             letter-spacing: .2px;
@@ -120,6 +158,14 @@
             color: #424242;
             font-weight: 400;
             margin-bottom: 1rem;
+        }
+
+        article ul, article ol {
+            margin-left: 1.8em;
+            list-style: revert;
+        }
+        article li {
+            margin-bottom: 0.25em;
         }
 
         article ul {

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -45,6 +45,15 @@ class Post extends Model
         'user_id' => 'integer',
     ];
 
+    public function getBodyAttribute($value)
+    {
+        if (! config('filamentblog.post_rendering.preserve_space_in_content')) {
+            return $value;
+        }
+        
+        return preg_replace('/<p>\s*<\/p>/', '<p>&nbsp;</p>', $value ?? '');
+    }
+
     protected static function newFactory()
     {
         return new PostFactory();


### PR DESCRIPTION
## Description
This PR enhances the visual rendering of blog post bodies and adds an opt‑in feature to preserve user‑added blank lines.

### Changes included
1. **CSS additions** (in `resources/views/layouts/app.blade.php`):
   - `h5`, `h6` – proper margins, font sizes, weights
   - `blockquote` – left border, padding, italic, color
   - `pre`, `code` – background, padding, border radius, monospace font
   - `ul`, `ol` – margin-left for indentation, `list-style: revert`
   - `li` – margin-bottom for spacing

2. **Empty paragraph preservation**:
   - New config key `features.preserve_space_in_content` (default `false`)
   - Override `getBodyAttribute()` in `Post` model to replace `<p>\s*<\/p>` with `<p>&nbsp;</p>` when enabled

### Why these changes?
- Without them, lists have no bullets/numbers, blockquotes are invisible, code is unstyled, and blank lines disappear.
- The new config gives users control without breaking existing behaviour.

### Related Issue
Closes #70 

### Checklist
- [x] Backward compatible
- [x] New feature disabled by default
- [x] CSS follows package’s existing pattern (inside `<style>` block)
- [x] Code tested locally